### PR TITLE
avoid taking or passing std::string over library interface, fix wrong…

### DIFF
--- a/include/DMDUtil/Config.h
+++ b/include/DMDUtil/Config.h
@@ -8,9 +8,8 @@
 #define DMDUTILCALLBACK
 #endif
 
-#include <cstdint>
 #include <string>
-#include <stdarg.h>
+#include <cstdarg>
 
 typedef void(DMDUTILCALLBACK *DMDUtil_LogCallback)(const char *format, va_list args);
 
@@ -20,32 +19,32 @@ class DMDUTILAPI Config
 {
 public:
    static Config* GetInstance();
-   bool IsAltColor() { return m_altColor; }
+   bool IsAltColor() const { return m_altColor; }
    void SetAltColor(bool altColor) { m_altColor = altColor; }
-   void SetAltColorPath(const std::string& path) { m_altColorPath = path; }
-   bool IsZeDMD() { return m_zedmd; }
+   void SetAltColorPath(const char* path) { m_altColorPath = path; }
+   bool IsZeDMD() const { return m_zedmd; }
    void SetZeDMD(bool zedmd) { m_zedmd = zedmd; }
-   const std::string& GetZeDMDDevice() { return m_zedmdDevice; }
-   void SetZeDMDDevice(const std::string& port) { m_zedmdDevice = port; }
-   const bool IsZeDMDDebug() { return m_zedmdDebug; }
+   const char* GetZeDMDDevice() const { return m_zedmdDevice.c_str(); }
+   void SetZeDMDDevice(const char* port) { m_zedmdDevice = port; }
+   bool IsZeDMDDebug() const { return m_zedmdDebug; }
    void SetZeDMDDebug(bool debug) { m_zedmdDebug = debug; }
-   const int GetZeDMDRGBOrder() { return m_zedmdRgbOrder; }
+   int GetZeDMDRGBOrder() const { return m_zedmdRgbOrder; }
    void SetZeDMDRGBOrder(int rgbOrder) { m_zedmdRgbOrder = rgbOrder; }
-   const int GetZeDMDBrightness() { return m_zedmdBrightness; }
+   int GetZeDMDBrightness() const { return m_zedmdBrightness; }
    void SetZeDMDBrightness(int brightness) { m_zedmdBrightness = brightness; }
-   const bool IsZeDMDSaveSettings() { return m_zedmdSaveSettings; }
+   bool IsZeDMDSaveSettings() const { return m_zedmdSaveSettings; }
    void SetZeDMDSaveSettings(bool saveSettings) { m_zedmdSaveSettings = saveSettings; }
-   bool IsPixelcade() { return m_pixelcade; }
+   bool IsPixelcade() const { return m_pixelcade; }
    void SetPixelcade(bool pixelcade) { m_pixelcade = pixelcade; }
-   void SetPixelcadeDevice(const std::string& port) { m_pixelcadeDevice = port; }
-   const std::string& GetPixelcadeDevice() { return m_pixelcadeDevice; }
-   DMDUtil_LogCallback GetLogCallback() { return m_logCallback; }
+   void SetPixelcadeDevice(const char* port) { m_pixelcadeDevice = port; }
+   const char* GetPixelcadeDevice() const { return m_pixelcadeDevice.c_str(); }
+   const DMDUtil_LogCallback GetLogCallback() const { return m_logCallback; }
    void SetLogCallback(DMDUtil_LogCallback callback) { m_logCallback = callback; }
-   const std::string& GetAltColorPath() { return m_altColorPath; }
+   const char* GetAltColorPath() const { return m_altColorPath.c_str(); }
 
 private:
    Config();
-   ~Config();
+   ~Config() {}
 
    static Config* m_pInstance;
    bool m_altColor;

--- a/include/DMDUtil/DMD.h
+++ b/include/DMDUtil/DMD.h
@@ -50,22 +50,22 @@ class Pixelcade;
 class DMDUTILAPI DMD
 {
 public:
-   DMD(int width, int height, bool sam = false, const std::string& name = "");
+   DMD(int width, int height, bool sam = false, const char* name = nullptr);
    ~DMD();
 
    static bool IsFinding();
-   bool HasDisplay();
-   const int GetWidth() { return m_width; }
-   const int GetHeight() { return m_height; }
-   const int GetLength() { return m_length; }
-   const bool IsUpdated() { return m_updated; }
+   bool HasDisplay() const;
+   int GetWidth() const { return m_width; }
+   int GetHeight() const { return m_height; }
+   int GetLength() const { return m_length; }
+   bool IsUpdated() const { return m_updated; }
    void ResetUpdated() { m_updated = false; }
    void UpdateData(const uint8_t* pData, int depth, uint8_t r, uint8_t g, uint8_t b);
    void UpdateRGB24Data(const uint8_t* pData, int depth, uint8_t r, uint8_t g, uint8_t b);
    void UpdateAlphaNumericData(AlphaNumericLayout layout, const uint16_t* pData1, const uint16_t* pData2, uint8_t r, uint8_t g, uint8_t b);
-   uint8_t* GetLevelData();
-   uint32_t* GetRGB32Data();
- 
+   const uint8_t* GetLevelData() const { return m_pLevelData; }
+   const uint32_t* GetRGB32Data() const { return m_pRGB32Data; }
+
 private:
    enum class DmdMode {
       Unknown,
@@ -103,8 +103,8 @@ private:
    bool m_sam;
    uint8_t* m_pData;
    uint8_t* m_pRGB24Data;
-   uint16_t* m_segData1[128];
-   uint16_t* m_segData2[128];
+   uint16_t m_segData1[128];
+   uint16_t m_segData2[128];
    uint8_t* m_pLevelData;
    uint32_t* m_pRGB32Data;
    uint16_t* m_pRGB565Data;

--- a/src/AlphaNumeric.cpp
+++ b/src/AlphaNumeric.cpp
@@ -7,9 +7,11 @@
 
 #include "AlphaNumeric.h"
 
+#include <cstring>
+
 namespace DMDUtil {
 
-uint8_t AlphaNumeric::SegSizes[8][16] = {
+const uint8_t AlphaNumeric::SegSizes[8][16] = {
    {5,5,5,5,5,5,2,2,5,5,5,2,5,5,5,1},
    {5,5,5,5,5,5,5,2,0,0,0,0,0,0,0,0},
    {5,5,5,5,5,5,5,2,5,5,0,0,0,0,0,0},
@@ -20,7 +22,7 @@ uint8_t AlphaNumeric::SegSizes[8][16] = {
    {5,5,5,5,5,5,3,2,5,5,5,3,5,5,5,1}
 };
 
-uint8_t AlphaNumeric::Segs[8][17][5][2] = {
+const uint8_t AlphaNumeric::Segs[8][17][5][2] = {
    /* alphanumeric display characters */
    {
       {{1,0},{2,0},{3,0},{4,0},{5,0}}, // 0 top
@@ -177,12 +179,12 @@ uint8_t AlphaNumeric::Segs[8][17][5][2] = {
 
 AlphaNumeric::AlphaNumeric()
 {
-   memset(m_frameBuffer, 0, 4096);
+   memset(m_frameBuffer, 0, sizeof(m_frameBuffer));
 }
 
-uint8_t* AlphaNumeric::Render(NumericalLayout layout, const uint16_t* const seg_data)
+uint8_t* AlphaNumeric::Render(AlphaNumericLayout layout, const uint16_t* const seg_data)
 {
-   if (layout != __2x7Num_2x7Num_10x1Num)
+   if (layout != AlphaNumericLayout::__2x7Num_2x7Num_10x1Num)
       Render(layout, seg_data, nullptr);
    else
       Render(layout, seg_data, seg_data + 32);
@@ -190,57 +192,57 @@ uint8_t* AlphaNumeric::Render(NumericalLayout layout, const uint16_t* const seg_
    return m_frameBuffer;
 }
 
-uint8_t* AlphaNumeric::Render(NumericalLayout layout, const uint16_t* const seg_data, const uint16_t* const seg_data2)
+uint8_t* AlphaNumeric::Render(AlphaNumericLayout layout, const uint16_t* const seg_data, const uint16_t* const seg_data2)
 {
    Clear();
 
    switch (layout) {
-      case __2x16Alpha:
+      case AlphaNumericLayout::__2x16Alpha:
          Render2x16Alpha(seg_data);
          break;
-      case __2x20Alpha:
+      case AlphaNumericLayout::__2x20Alpha:
          Render2x20Alpha(seg_data);
          break;
-      case __2x7Alpha_2x7Num:
+      case AlphaNumericLayout::__2x7Alpha_2x7Num:
          Render2x7Alpha_2x7Num(seg_data);
          break;
-      case __2x7Alpha_2x7Num_4x1Num:
+      case AlphaNumericLayout::__2x7Alpha_2x7Num_4x1Num:
          Render2x7Alpha_2x7Num_4x1Num(seg_data);
          break;
-      case __2x7Num_2x7Num_4x1Num:
+      case AlphaNumericLayout::__2x7Num_2x7Num_4x1Num:
          Render2x7Num_2x7Num_4x1Num(seg_data);
          break;
-      case __2x7Num_2x7Num_10x1Num:
+      case AlphaNumericLayout::__2x7Num_2x7Num_10x1Num:
          Render2x7Num_2x7Num_10x1Num(seg_data, seg_data2);
          break;
-      case __2x7Num_2x7Num_4x1Num_gen7:
+      case AlphaNumericLayout::__2x7Num_2x7Num_4x1Num_gen7:
          Render2x7Num_2x7Num_4x1Num_gen7(seg_data);
          break;
-      case __2x7Num10_2x7Num10_4x1Num:
+      case AlphaNumericLayout::__2x7Num10_2x7Num10_4x1Num:
          Render2x7Num10_2x7Num10_4x1Num(seg_data);
          break;
-      case __2x6Num_2x6Num_4x1Num:
+      case AlphaNumericLayout::__2x6Num_2x6Num_4x1Num:
          Render2x6Num_2x6Num_4x1Num(seg_data);
          break;
-      case __2x6Num10_2x6Num10_4x1Num:
+      case AlphaNumericLayout::__2x6Num10_2x6Num10_4x1Num:
          Render2x6Num10_2x6Num10_4x1Num(seg_data);
          break;
-      case __4x7Num10:
+      case AlphaNumericLayout::__4x7Num10:
          Render4x7Num10(seg_data);
          break;
-      case __6x4Num_4x1Num:
+      case AlphaNumericLayout::__6x4Num_4x1Num:
          Render6x4Num_4x1Num(seg_data);
          break;
-      case __2x7Num_4x1Num_1x16Alpha:
+      case AlphaNumericLayout::__2x7Num_4x1Num_1x16Alpha:
          Render2x7Num_4x1Num_1x16Alpha(seg_data);
          break;
-      case __1x16Alpha_1x16Num_1x7Num:
+      case AlphaNumericLayout::__1x16Alpha_1x16Num_1x7Num:
          Render1x16Alpha_1x16Num_1x7Num(seg_data);
          break;
-      case __1x7Num_1x16Alpha_1x16Num:
+      case AlphaNumericLayout::__1x7Num_1x16Alpha_1x16Num:
          Render1x7Num_1x16Alpha_1x16Num(seg_data);
          break;
-      case __1x16Alpha_1x16Num_1x7Num_1x4Num:
+      case AlphaNumericLayout::__1x16Alpha_1x16Num_1x7Num_1x4Num:
          Render1x16Alpha_1x16Num_1x7Num_1x4Num(seg_data);
          break;
       default:
@@ -280,7 +282,7 @@ void AlphaNumeric::DrawSegment(const int x, const int y, const uint8_t type, con
       DrawPixel(Segs[type][seg][i][0] + x, Segs[type][seg][i][1] + y, colour);
 }
 
-uint8_t AlphaNumeric::GetPixel(const int x, const int y)
+bool AlphaNumeric::GetPixel(const int x, const int y) const
 {
    return m_frameBuffer[y * 128 + x] > 0;
 }
@@ -292,14 +294,13 @@ void AlphaNumeric::DrawPixel(const int x, const int y, const uint8_t colour)
 
 void AlphaNumeric::Clear()
 {
-   memset(m_frameBuffer, 0, 4096);
+   memset(m_frameBuffer, 0, sizeof(m_frameBuffer));
 }
 
 void AlphaNumeric::Render2x16Alpha(const uint16_t* const seg_data)
 {
-   int i, j;
-   for (i = 0; i < 16; i++) {
-      for (j = 0; j < 16; j++) {
+   for (int i = 0; i < 16; i++) {
+      for (int j = 0; j < 16; j++) {
          if ((seg_data[i] >> j) & 0x1)
             DrawSegment(i * 8, 2, 0, j, 3);
          if ((seg_data[i + 16] >> j) & 0x1)
@@ -312,9 +313,8 @@ void AlphaNumeric::Render2x16Alpha(const uint16_t* const seg_data)
 
 void AlphaNumeric::Render2x20Alpha(const uint16_t* const seg_data)
 {
-   int i, j;
-   for (i = 0; i < 20; i++) {
-      for (j = 0; j < 16; j++) {
+   for (int i = 0; i < 20; i++) {
+      for (int j = 0; j < 16; j++) {
          if ((seg_data[i] >> j) & 0x1)
             DrawSegment((i * 6) + 4, 2, 7, j, 3);
          if ((seg_data[i + 20] >> j) & 0x1)
@@ -327,9 +327,8 @@ void AlphaNumeric::Render2x20Alpha(const uint16_t* const seg_data)
 
 void AlphaNumeric::Render2x7Alpha_2x7Num(const uint16_t* const seg_data)
 {
-   int i, j;
-   for (i = 0; i < 14; i++) {
-      for (j = 0; j < 16; j++) {
+   for (int i = 0; i < 14; i++) {
+      for (int j = 0; j < 16; j++) {
          // 2x7 alphanumeric
          if ((seg_data[i] >> j) & 0x1)
             DrawSegment((i + ((i < 7) ? 0 : 2)) * 8, 2, 0, j, 3);
@@ -344,9 +343,8 @@ void AlphaNumeric::Render2x7Alpha_2x7Num(const uint16_t* const seg_data)
 
 void AlphaNumeric::Render2x7Alpha_2x7Num_4x1Num(const uint16_t* const seg_data)
 {
-   int i, j;
-   for (i = 0; i < 14; i++) {
-      for (j = 0; j < 16; j++) {
+   for (int i = 0; i < 14; i++) {
+      for (int j = 0; j < 16; j++) {
          // 2x7 alphanumeric
          if ((seg_data[i] >> j) & 0x1)
             DrawSegment((i + ((i < 7) ? 0 : 2)) * 8, 0, 0, j, 3);
@@ -358,7 +356,7 @@ void AlphaNumeric::Render2x7Alpha_2x7Num_4x1Num(const uint16_t* const seg_data)
       SmoothDigitCorners((i + ((i < 7) ? 0 : 2)) * 8, 21);
    }
    // 4x1 numeric small
-   for (j = 0; j < 16; j++) {
+   for (int j = 0; j < 16; j++) {
       if ((seg_data[28] >> j) & 0x1)
          DrawSegment(8, 12, 5, j, 3);
       if ((seg_data[29] >> j) & 0x1)
@@ -372,9 +370,8 @@ void AlphaNumeric::Render2x7Alpha_2x7Num_4x1Num(const uint16_t* const seg_data)
 
 void AlphaNumeric::Render2x6Num_2x6Num_4x1Num(const uint16_t* const seg_data)
 {
-   int i, j;
-   for (i = 0; i < 12; i++) {
-      for (j = 0; j < 16; j++) {
+   for (int i = 0; i < 12; i++) {
+      for (int j = 0; j < 16; j++) {
          // 2x7 numeric
          if ((seg_data[i] >> j) & 0x1)
             DrawSegment((i + ((i < 6) ? 0 : 4)) * 8, 0, 1, j, 3);
@@ -387,7 +384,7 @@ void AlphaNumeric::Render2x6Num_2x6Num_4x1Num(const uint16_t* const seg_data)
       SmoothDigitCorners((i + ((i < 6) ? 0 : 4)) * 8, 12);
    }
    // 4x1 numeric small
-   for (j = 0; j < 16; j++) {
+   for (int j = 0; j < 16; j++) {
       if ((seg_data[24] >> j) & 0x1)
          DrawSegment(8, 24, 5, j, 3);
       if ((seg_data[25] >> j) & 0x1)
@@ -401,9 +398,8 @@ void AlphaNumeric::Render2x6Num_2x6Num_4x1Num(const uint16_t* const seg_data)
 
 void AlphaNumeric::Render2x6Num10_2x6Num10_4x1Num(const uint16_t* const seg_data)
 {
-   int i, j;
-   for (i = 0; i < 12; i++) {
-      for (j = 0; j < 16; j++) {
+   for (int i = 0; i < 12; i++) {
+      for (int j = 0; j < 16; j++) {
          // 2x7 numeric
          if ((seg_data[i] >> j) & 0x1)
             DrawSegment((i + ((i < 6) ? 0 : 4)) * 8, 0, 2, j, 3);
@@ -415,7 +411,7 @@ void AlphaNumeric::Render2x6Num10_2x6Num10_4x1Num(const uint16_t* const seg_data
       SmoothDigitCorners((i + ((i < 6) ? 0 : 4)) * 8, 20);
    }
    // 4x1 numeric small
-   for (j = 0; j < 16; j++) {
+   for (int j = 0; j < 16; j++) {
       if ((seg_data[24] >> j) & 0x1)
          DrawSegment(8, 12, 5, j, 3);
       if ((seg_data[25] >> j) & 0x1)
@@ -429,9 +425,8 @@ void AlphaNumeric::Render2x6Num10_2x6Num10_4x1Num(const uint16_t* const seg_data
 
 void AlphaNumeric::Render2x7Num_2x7Num_4x1Num(const uint16_t* const seg_data)
 {
-   int i, j;
-   for (i = 0; i < 14; i++) {
-      for (j = 0; j < 16; j++) {
+   for (int i = 0; i < 14; i++) {
+      for (int j = 0; j < 16; j++) {
          // 2x7 numeric
          if ((seg_data[i] >> j) & 0x1)
             DrawSegment((i + ((i < 7) ? 0 : 2)) * 8, 0, 1, j, 3);
@@ -443,7 +438,7 @@ void AlphaNumeric::Render2x7Num_2x7Num_4x1Num(const uint16_t* const seg_data)
       SmoothDigitCorners((i + ((i < 7) ? 0 : 2)) * 8, 12);
    }
    // 4x1 numeric small
-   for (j = 0; j < 16; j++) {
+   for (int j = 0; j < 16; j++) {
       if ((seg_data[28] >> j) & 0x1)
          DrawSegment(16, 24, 5, j, 3);
       if ((seg_data[29] >> j) & 0x1)
@@ -457,9 +452,8 @@ void AlphaNumeric::Render2x7Num_2x7Num_4x1Num(const uint16_t* const seg_data)
 
 void AlphaNumeric::Render2x7Num_2x7Num_10x1Num(const uint16_t* const seg_data, const uint16_t* const extra_seg_data)
 {
-   int i, j;
-   for (i = 0; i < 14; i++) {
-      for (j = 0; j < 16; j++) {
+   for (int i = 0; i < 14; i++) {
+      for (int j = 0; j < 16; j++) {
          // 2x7 numeric
          if ((seg_data[i] >> j) & 0x1)
             DrawSegment((i + ((i < 7) ? 0 : 2)) * 8, 0, 1, j, 3);
@@ -471,7 +465,7 @@ void AlphaNumeric::Render2x7Num_2x7Num_10x1Num(const uint16_t* const seg_data, c
       SmoothDigitCorners((i + ((i < 7) ? 0 : 2)) * 8, 12);
    }
    // 10x1 numeric small
-   for (j = 0; j < 16; j++) {
+   for (int j = 0; j < 16; j++) {
       if ((seg_data[28] >> j) & 0x1)
          DrawSegment(16, 24, 5, j, 3);
       if ((seg_data[29] >> j) & 0x1)
@@ -497,9 +491,8 @@ void AlphaNumeric::Render2x7Num_2x7Num_10x1Num(const uint16_t* const seg_data, c
 
 void AlphaNumeric::Render2x7Num_2x7Num_4x1Num_gen7(const uint16_t* const seg_data)
 {
-   int i, j;
-   for (i = 0; i < 14; i++) {
-      for (j = 0; j < 16; j++) {
+   for (int i = 0; i < 14; i++) {
+      for (int j = 0; j < 16; j++) {
          // 2x7 numeric
          if ((seg_data[i] >> j) & 0x1)
             DrawSegment((i + ((i < 7) ? 0 : 2)) * 8, 21, 1, j, 3);
@@ -511,7 +504,7 @@ void AlphaNumeric::Render2x7Num_2x7Num_4x1Num_gen7(const uint16_t* const seg_dat
       SmoothDigitCorners((i + ((i < 7) ? 0 : 2)) * 8, 1);
    }
    // 4x1 numeric small
-   for (j = 0; j < 16; j++) {
+   for (int j = 0; j < 16; j++) {
       if ((seg_data[28] >> j) & 0x1)
          DrawSegment(8, 13, 5, j, 3);
       if ((seg_data[29] >> j) & 0x1)
@@ -525,9 +518,8 @@ void AlphaNumeric::Render2x7Num_2x7Num_4x1Num_gen7(const uint16_t* const seg_dat
 
 void AlphaNumeric::Render2x7Num10_2x7Num10_4x1Num(const uint16_t* const seg_data)
 {
-   int i, j;
-   for (i = 0; i < 14; i++) {
-      for (j = 0; j < 16; j++) {
+   for (int i = 0; i < 14; i++) {
+      for (int j = 0; j < 16; j++) {
          // 2x7 numeric
          if ((seg_data[i] >> j) & 0x1)
             DrawSegment((i + ((i < 7) ? 0 : 2)) * 8, 0, 2, j, 3);
@@ -539,7 +531,7 @@ void AlphaNumeric::Render2x7Num10_2x7Num10_4x1Num(const uint16_t* const seg_data
       SmoothDigitCorners((i + ((i < 7) ? 0 : 2)) * 8, 20);
    }
    // 4x1 numeric small
-   for (j = 0; j < 16; j++) {
+   for (int j = 0; j < 16; j++) {
       if ((seg_data[28] >> j) & 0x1)
          DrawSegment(8, 12, 5, j, 3);
       if ((seg_data[29] >> j) & 0x1)
@@ -553,9 +545,8 @@ void AlphaNumeric::Render2x7Num10_2x7Num10_4x1Num(const uint16_t* const seg_data
 
 void AlphaNumeric::Render4x7Num10(const uint16_t* const seg_data)
 {
-   int i, j;
-   for (i = 0; i < 14; i++) {
-      for (j = 0; j < 16; j++) {
+   for (int i = 0; i < 14; i++) {
+      for (int j = 0; j < 16; j++) {
          // 2x7 numeric10
          if ((seg_data[i] >> j) & 0x1)
             DrawSegment((i + ((i < 7) ? 0 : 2)) * 8, 1, 2, j, 3);
@@ -570,9 +561,8 @@ void AlphaNumeric::Render4x7Num10(const uint16_t* const seg_data)
 
 void AlphaNumeric::Render6x4Num_4x1Num(const uint16_t* const seg_data)
 {
-   int i, j;
-   for (i = 0; i < 8; i++) {
-      for (j = 0; j < 16; j++) {
+   for (int i = 0; i < 8; i++) {
+      for (int j = 0; j < 16; j++) {
          // 2x4 numeric
          if ((seg_data[i] >> j) & 0x1)
             DrawSegment((i + ((i < 4) ? 0 : 2)) * 8, 1, 5, j, 3);
@@ -588,7 +578,7 @@ void AlphaNumeric::Render6x4Num_4x1Num(const uint16_t* const seg_data)
       SmoothDigitCorners((i + ((i < 4) ? 0 : 2)) * 8, 17);
    }
    // 4x1 numeric small
-   for (j = 0; j < 16; j++) {
+   for (int j = 0; j < 16; j++) {
       if ((seg_data[24] >> j) & 0x1)
          DrawSegment(16, 25, 5, j, 3);
       if ((seg_data[25] >> j) & 0x1)
@@ -602,9 +592,8 @@ void AlphaNumeric::Render6x4Num_4x1Num(const uint16_t* const seg_data)
 
 void AlphaNumeric::Render2x7Num_4x1Num_1x16Alpha(const uint16_t* const seg_data)
 {
-   int i, j;
-   for (i = 0; i < 14; i++) {
-      for (j = 0; j < 16; j++) {
+   for (int i = 0; i < 14; i++) {
+      for (int j = 0; j < 16; j++) {
          // 2x7 numeric
          if ((seg_data[i] >> j) & 0x1)
             DrawSegment((i + ((i < 7) ? 0 : 2)) * 8, 0, 1, j, 3);
@@ -612,7 +601,7 @@ void AlphaNumeric::Render2x7Num_4x1Num_1x16Alpha(const uint16_t* const seg_data)
       SmoothDigitCorners((i + ((i < 7) ? 0 : 2)) * 8, 0);
    }
    // 4x1 numeric small
-   for (j = 0; j < 16; j++) {
+   for (int j = 0; j < 16; j++) {
       if ((seg_data[14] >> j) & 0x1)
          DrawSegment(16, 12, 5, j, 3);
       if ((seg_data[15] >> j) & 0x1)
@@ -623,8 +612,8 @@ void AlphaNumeric::Render2x7Num_4x1Num_1x16Alpha(const uint16_t* const seg_data)
          DrawSegment(48, 12, 5, j, 3);
    }
    // 1x16 alphanumeric
-   for (i = 0; i < 12; i++) {
-      for (j = 0; j < 16; j++) {
+   for (int i = 0; i < 12; i++) {
+      for (int j = 0; j < 16; j++) {
          if ((seg_data[i + 18] >> j) & 0x1)
             DrawSegment((i * 8) + 16, 21, 0, j, 3);
       }
@@ -634,10 +623,9 @@ void AlphaNumeric::Render2x7Num_4x1Num_1x16Alpha(const uint16_t* const seg_data)
 
 void AlphaNumeric::Render1x16Alpha_1x16Num_1x7Num(const uint16_t* const seg_data)
 {
-   int i, j;
    // 1x16 alphanumeric
-   for (i = 0; i < 16; i++) {
-      for (j = 0; j < 16; j++) {
+   for (int i = 0; i < 16; i++) {
+      for (int j = 0; j < 16; j++) {
          if ((seg_data[i] >> j) & 0x1)
             DrawSegment((i * 8), 9, 0, j, 3);
       }
@@ -645,8 +633,8 @@ void AlphaNumeric::Render1x16Alpha_1x16Num_1x7Num(const uint16_t* const seg_data
    }
 
    // 1x16 numeric
-   for (i = 0; i < 16; i++) {
-      for (j = 0; j < 16; j++) {
+   for (int i = 0; i < 16; i++) {
+      for (int j = 0; j < 16; j++) {
          if ((seg_data[i + 16] >> j) & 0x1)
             DrawSegment((i * 8), 21, 1, j, 3);
       }
@@ -654,8 +642,8 @@ void AlphaNumeric::Render1x16Alpha_1x16Num_1x7Num(const uint16_t* const seg_data
    }
 
    // 1x7 numeric small
-   for (i = 0; i < 7; i++) {
-      for (j = 0; j < 16; j++) {
+   for (int i = 0; i < 7; i++) {
+      for (int j = 0; j < 16; j++) {
          if ((seg_data[i + 32] >> j) & 0x1)
             DrawSegment((i * 8) + 68, 1, 5, j, 3);
       }
@@ -664,26 +652,25 @@ void AlphaNumeric::Render1x16Alpha_1x16Num_1x7Num(const uint16_t* const seg_data
 
 void AlphaNumeric::Render1x7Num_1x16Alpha_1x16Num(const uint16_t* const seg_data)
 {
-   int i, j;
    // 1x16 alphanumeric
-   for (i = 0; i < 16; i++) {
-      for (j = 0; j < 16; j++) {
+   for (int i = 0; i < 16; i++) {
+      for (int j = 0; j < 16; j++) {
          if ((seg_data[i+8] >> j) & 0x1)
             DrawSegment((i * 8), 9, 0, j, 3);
       }
       SmoothDigitCorners((i * 8), 9);
    }
    // 1x16 numeric
-   for (i = 0; i < 16; i++) {
-      for (j = 0; j < 16; j++) {
+   for (int i = 0; i < 16; i++) {
+      for (int j = 0; j < 16; j++) {
          if ((seg_data[i + 24] >> j) & 0x1)
             DrawSegment((i * 8), 21, 1, j, 3);
       }
       SmoothDigitCorners((i * 8), 21);
    }
    // 1x7 numeric small
-   for (i = 0; i < 7; i++) {
-      for (j = 0; j < 16; j++) {
+   for (int i = 0; i < 7; i++) {
+      for (int j = 0; j < 16; j++) {
          if ((seg_data[i+1] >> j) & 0x1)
             DrawSegment((i * 8) + 68, 1, 5, j, 3);
       }
@@ -692,33 +679,32 @@ void AlphaNumeric::Render1x7Num_1x16Alpha_1x16Num(const uint16_t* const seg_data
 
 void AlphaNumeric::Render1x16Alpha_1x16Num_1x7Num_1x4Num(const uint16_t* const seg_data)
 {
-   int i, j;
    // 1x16 alphanumeric
-   for (i = 0; i < 16; i++) {
-      for (j = 0; j < 16; j++) {
+   for (int i = 0; i < 16; i++) {
+      for (int j = 0; j < 16; j++) {
          if ((seg_data[i + 11] >> j) & 0x1)
             DrawSegment((i * 8), 9, 0, j, 3);
       }
       SmoothDigitCorners((i * 8), 9);
    }
    // 1x16 numeric
-   for (i = 0; i < 16; i++) {
-      for (j = 0; j < 16; j++) {
+   for (int i = 0; i < 16; i++) {
+      for (int j = 0; j < 16; j++) {
          if ((seg_data[i + 27] >> j) & 0x1)
             DrawSegment((i * 8), 21, 1, j, 3);
       }
       SmoothDigitCorners((i * 8), 21);
    }
    // 1x4 numeric small
-   for (i = 0; i < 4; i++) {
-      for (j = 0; j < 16; j++) {
+   for (int i = 0; i < 4; i++) {
+      for (int j = 0; j < 16; j++) {
          if ((seg_data[i + 7] >> j) & 0x1)
             DrawSegment((i * 8)+4, 1, 5, j, 3);
       }
    }
    // 1x7 numeric small
-   for (i = 0; i < 7; i++) {
-      for (j = 0; j < 16; j++) {
+   for (int i = 0; i < 7; i++) {
+      for (int j = 0; j < 16; j++) {
          if ((seg_data[i] >> j) & 0x1)
             DrawSegment((i * 8)+68, 1, 5, j, 3);
       }

--- a/src/AlphaNumeric.h
+++ b/src/AlphaNumeric.h
@@ -7,45 +7,26 @@
 
 #pragma once
 
+#include "DMDUtil/DMD.h"
+
 #include <cstdint>
-#include <cstring>
 
 namespace DMDUtil {
-
-typedef enum {
-   None,
-   __2x16Alpha,
-   __2x20Alpha,
-   __2x7Alpha_2x7Num,
-   __2x7Alpha_2x7Num_4x1Num,
-   __2x7Num_2x7Num_4x1Num,
-   __2x7Num_2x7Num_10x1Num,
-   __2x7Num_2x7Num_4x1Num_gen7,
-   __2x7Num10_2x7Num10_4x1Num,
-   __2x6Num_2x6Num_4x1Num,
-   __2x6Num10_2x6Num10_4x1Num,
-   __4x7Num10,
-   __6x4Num_4x1Num,
-   __2x7Num_4x1Num_1x16Alpha,
-   __1x16Alpha_1x16Num_1x7Num,
-   __1x7Num_1x16Alpha_1x16Num,
-   __1x16Alpha_1x16Num_1x7Num_1x4Num
-} NumericalLayout;
 
 class AlphaNumeric
 {
 public:
    AlphaNumeric();
-   ~AlphaNumeric() {};
+   ~AlphaNumeric() {}
 
-   uint8_t* Render(NumericalLayout layout, const uint16_t* const seg_data);
-   uint8_t* Render(NumericalLayout layout, const uint16_t* const seg_data, const uint16_t* const seg_data2);
+   uint8_t* Render(AlphaNumericLayout layout, const uint16_t* const seg_data);
+   uint8_t* Render(AlphaNumericLayout layout, const uint16_t* const seg_data, const uint16_t* const seg_data2);
 
 private:
    void SmoothDigitCorners(const int x, const int y);
    void SmoothDigitCorners6Px(const int x, const int y);
    void DrawSegment(const int x, const int y, const uint8_t type, const uint16_t seg, const uint8_t colour);
-   uint8_t GetPixel(const int x, const int y);
+   bool GetPixel(const int x, const int y) const;
    void DrawPixel(const int x, const int y, const uint8_t colour);
    void Clear();
 
@@ -68,8 +49,8 @@ private:
 
    uint8_t m_frameBuffer[4096];
 
-   static uint8_t SegSizes[8][16];
-   static uint8_t Segs[8][17][5][2];
+   static const uint8_t SegSizes[8][16];
+   static const uint8_t Segs[8][17][5][2];
 };
 
 }

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -15,20 +15,16 @@ Config* Config::GetInstance()
 Config::Config()
 {
    m_altColor = true;
-   m_altColorPath = "";
+   m_altColorPath.clear();
    m_zedmd = true;
-   m_zedmdDevice = "";
+   m_zedmdDevice.clear();
    m_zedmdDebug = false;
    m_zedmdRgbOrder = -1;
    m_zedmdBrightness = -1;
    m_zedmdSaveSettings = false;
    m_pixelcade = true;
-   m_pixelcadeDevice = "";
+   m_pixelcadeDevice.clear();
    m_logCallback = nullptr;
-}
-
-Config::~Config()
-{
 }
 
 }

--- a/src/DMD.cpp
+++ b/src/DMD.cpp
@@ -11,6 +11,8 @@
 #include "Serum.h"
 #include "ZeDMD.h"
 
+#include <cstring>
+
 namespace DMDUtil {
 
 void ZEDMDCALLBACK ZeDMDLogCallback(const char* format, va_list args, const void* pUserData)

--- a/src/Pixelcade.h
+++ b/src/Pixelcade.h
@@ -26,13 +26,13 @@ namespace DMDUtil {
 class Pixelcade
 {
 public:
+   Pixelcade(struct sp_port* pSerialPort, int width, int height);
    ~Pixelcade();
 
    static Pixelcade* Connect(const char* pDevice, int width, int height);
    void Update(uint16_t* pData);
 
 private:
-   Pixelcade(struct sp_port* pSerialPort, int width, int height);
    static Pixelcade* Open(const char* pDevice, int width, int height);
    void Run();
    void Stop();

--- a/src/Serum.cpp
+++ b/src/Serum.cpp
@@ -1,4 +1,5 @@
 #include "Serum.h"
+#include "serum-decode.h"
 #include "DMDUtil/Config.h"
 #include "Logger.h"
 
@@ -19,8 +20,7 @@ Serum::Serum(int width, int height)
 
 Serum::~Serum()
 {
-   if (m_pFrame)
-      free(m_pFrame);
+   free(m_pFrame);
 
    Serum_Dispose();
 
@@ -52,8 +52,6 @@ Serum* Serum::Load(const std::string& romName)
    m_isLoaded = true;
 
    return new Serum(width, height);
-
-   return nullptr;
 }
 
 bool Serum::Convert(uint8_t* pFrame, uint8_t* pDstFrame, uint8_t* pDstPalette)

--- a/src/Serum.h
+++ b/src/Serum.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "serum-decode.h"
-
 #include <cstdint>
 #include <string>
 

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -48,7 +48,7 @@ int main(int argc, const char* argv[]) {
 
    printf("Finding displays...\n");
 
-   while (pDmd->IsFinding())
+   while (DMDUtil::DMD::IsFinding())
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
    if (!pDmd->HasDisplay()) {


### PR DESCRIPTION
… declaration of m_segData1/2, avoid duplicating NumericalLayout, (most likely) fix wrong detection of pixelcade magic code string

Please decide if the change from std::string to char* makes sense, but from all that i know, passing std::strings over API borders is always kinda tricky, unless one can guarantee that the string implementation will match exactly on both sides.

And please double check the pixelcade magic code detection.