### PR TITLE
fix: add missing cstdint include

### DIFF
--- a/include/DMDUtil/Config.h
+++ b/include/DMDUtil/Config.h
@@ -9,6 +9,7 @@
 #endif
 
 #include <cstdarg>
+#include <cstdint>
 #include <string>
 
 typedef enum


### PR DESCRIPTION
fixes building on Ubuntu 24.04