### PR TITLE
pixelcade: add support for detecting color swap from firmware

### DIFF
--- a/.github/workflows/libdmdutil.yml
+++ b/.github/workflows/libdmdutil.yml
@@ -69,7 +69,7 @@ jobs:
       - if: (matrix.os == 'macos-latest')
         name: Add autoconf and automake (mac runner)
         run: |
-           brew install autoconf automake 
+           brew install autoconf automake libtool
       - if: (!(matrix.platform == 'linux' && matrix.arch == 'aarch64'))
         name: Build libdmdutil-${{ matrix.platform }}-${{ matrix.arch }}
         run: |

--- a/README.md
+++ b/README.md
@@ -209,8 +209,6 @@ SaveSettings = 0
 Enabled = 1
 # Disable auto-detection and provide a fixed serial port
 Device =
-# Set to 0 if RGB, 1 if RBG.
-Matrix = 0
 ```
 
 ## Building:

--- a/dmdserver.ini
+++ b/dmdserver.ini
@@ -39,5 +39,3 @@ SaveSettings = 0
 Enabled = 1
 # Disable auto-detection and provide a fixed serial port
 Device =
-# Set to 0 if RGB, 1 if RBG.
-Matrix = 0

--- a/include/DMDUtil/Config.h
+++ b/include/DMDUtil/Config.h
@@ -66,8 +66,6 @@ class DMDUTILAPI Config
   void SetPixelcade(bool pixelcade) { m_pixelcade = pixelcade; }
   void SetPixelcadeDevice(const char* port) { m_pixelcadeDevice = port; }
   const char* GetPixelcadeDevice() const { return m_pixelcadeDevice.c_str(); }
-  int GetPixelcadeMatrix() const { return m_pixelcadeMatrix; }
-  void SetPixelcadeMatrix(int matrix) { m_pixelcadeMatrix = matrix; }
   void SetDMDServer(bool dmdServer) { m_dmdServer = dmdServer; }
   bool IsDmdServer() { return m_dmdServer; }
   void SetDMDServerAddr(const char* addr) { m_dmdServerAddr = addr; }
@@ -108,7 +106,6 @@ class DMDUTILAPI Config
   int m_dmdServerPort;
   bool m_pixelcade;
   std::string m_pixelcadeDevice;
-  int m_pixelcadeMatrix;
   DMDUtil_LogLevel m_logLevel;
   DMDUtil_LogCallback m_logCallback;
   DMDUtil_PUPTriggerCallbackContext m_pupTriggerCallbackContext;

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -31,7 +31,6 @@ Config::Config()
   m_zedmdSaveSettings = false;
   m_pixelcade = true;
   m_pixelcadeDevice.clear();
-  m_pixelcadeMatrix = 0;
   m_dmdServer = false;
   m_dmdServerAddr = "localhost";
   m_dmdServerPort = 6789;

--- a/src/DMD.cpp
+++ b/src/DMD.cpp
@@ -756,7 +756,7 @@ void DMD::PixelcadeDMDThread()
       if (m_pUpdateBufferQueue[bufferPosition]->hasData || m_pUpdateBufferQueue[bufferPosition]->hasSegData)
       {
         uint16_t width = m_pUpdateBufferQueue[bufferPosition]->width;
-        uint8_t height = m_pUpdateBufferQueue[bufferPosition]->height;
+        uint16_t height = m_pUpdateBufferQueue[bufferPosition]->height;
         int length = width * height;
         uint8_t depth = m_pUpdateBufferQueue[bufferPosition]->depth;
 
@@ -776,7 +776,7 @@ void DMD::PixelcadeDMDThread()
 
           uint8_t scaledBuffer[128 * 32 * 3];
           if (width == 128 && height == 32)
-            memcpy(scaledBuffer, m_pUpdateBufferQueue[bufferPosition]->segData, 128 * 32 * 3);
+            memcpy(scaledBuffer, rgb24Data, 128 * 32 * 3);
           else if (width == 128 && height == 16)
             FrameUtil::Helper::Center(scaledBuffer, 128, 32, rgb24Data, 128, 16, 24);
           else if (width == 192 && height == 64)
@@ -786,7 +786,7 @@ void DMD::PixelcadeDMDThread()
           else
             continue;
 
-          for (int i = 0; i < length; i++)
+          for (int i = 0; i < 128 * 32; i++)
           {
             int pos = i * 3;
             uint32_t r = scaledBuffer[pos];
@@ -885,7 +885,7 @@ void DMD::PixelcadeDMDThread()
 
           if (update)
           {
-            for (int i = 0; i < length; i++)
+            for (int i = 0; i < 128 * 32; i++)
             {
               int pos = renderBuffer[i] * 3;
               uint32_t r = palette[pos];
@@ -1389,7 +1389,7 @@ void DMD::PupDMDThread()
           m_pUpdateBufferQueue[bufferPosition]->mode == Mode::Data && m_pUpdateBufferQueue[bufferPosition]->depth != 24)
       {
         uint16_t width = m_pUpdateBufferQueue[bufferPosition]->width;
-        uint8_t height = m_pUpdateBufferQueue[bufferPosition]->height;
+        uint16_t height = m_pUpdateBufferQueue[bufferPosition]->height;
         int length = width * height;
 
         if (memcmp(renderBuffer, m_pUpdateBufferQueue[bufferPosition]->data, length) != 0)

--- a/src/DMD.cpp
+++ b/src/DMD.cpp
@@ -505,7 +505,7 @@ void DMD::FindDisplays()
           if (pConfig->IsPixelcade())
           {
             pPixelcadeDMD =
-                PixelcadeDMD::Connect(pConfig->GetPixelcadeDevice(), pConfig->GetPixelcadeMatrix(), 128, 32);
+                PixelcadeDMD::Connect(pConfig->GetPixelcadeDevice(), 128, 32);
             if (pPixelcadeDMD) m_pPixelcadeDMDThread = new std::thread(&DMD::PixelcadeDMDThread, this);
           }
 

--- a/src/PixelcadeDMD.h
+++ b/src/PixelcadeDMD.h
@@ -27,21 +27,21 @@ namespace DMDUtil
 class PixelcadeDMD
 {
  public:
-  PixelcadeDMD(struct sp_port* pSerialPort, int matrix, int width, int height);
+  PixelcadeDMD(struct sp_port* pSerialPort, int width, int height, bool colorSwap);
   ~PixelcadeDMD();
 
-  static PixelcadeDMD* Connect(const char* pDevice, int matrix, int width, int height);
+  static PixelcadeDMD* Connect(const char* pDevice, int width, int height);
   void Update(uint16_t* pData);
 
  private:
-  static PixelcadeDMD* Open(const char* pDevice, int matrix, int width, int height);
+  static PixelcadeDMD* Open(const char* pDevice, int width, int height);
   void Run();
   void EnableRgbLedMatrix(int shifterLen32, int rows);
 
   struct sp_port* m_pSerialPort;
-  int m_matrix;
   int m_width;
   int m_height;
+  bool m_colorSwap;
   int m_length;
 
   std::thread* m_pThread;

--- a/src/dmdServer.cpp
+++ b/src/dmdServer.cpp
@@ -289,7 +289,6 @@ int main(int argc, char* argv[])
       // Pixelcade
       pConfig->SetPixelcade(r.Get<bool>("Pixelcade", "Enabled", true));
       pConfig->SetPixelcadeDevice(r.Get<string>("Pixelcade", "Device", "").c_str());
-      pConfig->SetPixelcadeMatrix(r.Get<int>("Pixelcade", "Matrix", -1));
 
       if (opt_verbose) DMDUtil::Log(DMDUtil_LogLevel_INFO, "Loaded config file");
     }


### PR DESCRIPTION
This PR also fixes incomplete rendering on Pixelcade for 128x16 games and fixes missing rendering for RGB24 games.