### PR TITLE
misc: remove sockpp reference from DMD.h

### DIFF
--- a/include/DMDUtil/DMD.h
+++ b/include/DMDUtil/DMD.h
@@ -24,8 +24,6 @@
 #include <string>
 #include <thread>
 
-#include "sockpp/tcp_connector.h"
-
 #if defined(__APPLE__)
 #include <TargetConditionals.h>
 #endif
@@ -70,6 +68,8 @@ class PixelcadeDMD;
 class LevelDMD;
 class RGB24DMD;
 class ConsoleDMD;
+
+class DMDServerConnector;
 
 class DMDUTILAPI DMD
 {
@@ -202,7 +202,7 @@ class DMDUTILAPI DMD
   std::vector<LevelDMD*> m_levelDMDs;
   std::vector<RGB24DMD*> m_rgb24DMDs;
   std::vector<ConsoleDMD*> m_consoleDMDs;
-  sockpp::tcp_connector* m_pDMDServerConnector;
+  DMDServerConnector* m_pDMDServerConnector;
   bool m_dmdServerDisconnectOthers = false;
 
   std::thread* m_pLevelDMDThread;


### PR DESCRIPTION
including dmdutil.h would force you to have a sockpp header file.

sockpp is just a support library, so we really shouldn't force users to require any headers from it.

I tried to do a forward declaration, but since it is a typedef alias, that wouldn't work.

So I decided to wrap it with a `DMDServerConnector`.

This is in support of switching vpx to use external.sh for all builds including windows.
