### PR TITLE
Improve txt dumper

### DIFF
--- a/include/DMDUtil/Config.h
+++ b/include/DMDUtil/Config.h
@@ -51,6 +51,8 @@ class DMDUTILAPI Config
   void SetMaximumUnknownFramesToSkip(int framesToSkip) { m_framesToSkip = framesToSkip; }
   int GetIgnoreUnknownFramesTimeout() { return m_framesTimeout; }
   int GetMaximumUnknownFramesToSkip() { return m_framesToSkip; }
+  bool IsDumpNotColorizedFrames() const { return m_dumpNotColorizedFrames; }
+  void SetDumpNotColorizedFrames(bool dumpNotColorizedFrames) { m_dumpNotColorizedFrames = dumpNotColorizedFrames; }
   bool IsZeDMD() const { return m_zedmd; }
   void SetZeDMD(bool zedmd) { m_zedmd = zedmd; }
   const char* GetZeDMDDevice() const { return m_zedmdDevice.c_str(); }
@@ -96,6 +98,7 @@ class DMDUTILAPI Config
   bool m_pupExactColorMatch;
   int m_framesTimeout;
   int m_framesToSkip;
+  bool m_dumpNotColorizedFrames;
   bool m_zedmd;
   std::string m_zedmdDevice;
   bool m_zedmdDebug;

--- a/include/DMDUtil/Config.h
+++ b/include/DMDUtil/Config.h
@@ -53,6 +53,11 @@ class DMDUTILAPI Config
   int GetMaximumUnknownFramesToSkip() { return m_framesToSkip; }
   bool IsDumpNotColorizedFrames() const { return m_dumpNotColorizedFrames; }
   void SetDumpNotColorizedFrames(bool dumpNotColorizedFrames) { m_dumpNotColorizedFrames = dumpNotColorizedFrames; }
+  bool IsFilterTransitionalFrames() const { return m_filterTransitionalFrames; }
+  void SetFilterTransitionalFrames(bool filterTransitionalFrames)
+  {
+    m_filterTransitionalFrames = filterTransitionalFrames;
+  }
   bool IsZeDMD() const { return m_zedmd; }
   void SetZeDMD(bool zedmd) { m_zedmd = zedmd; }
   const char* GetZeDMDDevice() const { return m_zedmdDevice.c_str(); }
@@ -99,6 +104,7 @@ class DMDUTILAPI Config
   int m_framesTimeout;
   int m_framesToSkip;
   bool m_dumpNotColorizedFrames;
+  bool m_filterTransitionalFrames;
   bool m_zedmd;
   std::string m_zedmdDevice;
   bool m_zedmdDebug;

--- a/include/DMDUtil/DMD.h
+++ b/include/DMDUtil/DMD.h
@@ -89,6 +89,7 @@ class DMDUTILAPI DMD
     SerumV2_32_64,  // int 7
     SerumV2_64,     // int 8
     SerumV2_64_32,  // int 9
+    NotColorized,   // int 10
   };
 
   bool IsSerumMode(Mode mode)

--- a/include/DMDUtil/DMD.h
+++ b/include/DMDUtil/DMD.h
@@ -79,17 +79,17 @@ class DMDUTILAPI DMD
 
   enum class Mode
   {
-    Unknown,        // int 0
-    Data,           // int 1
-    RGB24,          // int 2, RGB888
-    RGB16,          // int 3, RGB565
-    AlphaNumeric,   // int 4
-    SerumV1,        // int 5
-    SerumV2_32,     // int 6
-    SerumV2_32_64,  // int 7
-    SerumV2_64,     // int 8
-    SerumV2_64_32,  // int 9
-    NotColorized,   // int 10
+    Unknown = 0,
+    Data = 1,
+    RGB24 = 2,  // RGB888
+    RGB16 = 3,  // RGB565
+    AlphaNumeric = 4,
+    SerumV1 = 5,
+    SerumV2_32 = 6,
+    SerumV2_32_64 = 7,
+    SerumV2_64 = 8,
+    SerumV2_64_32 = 9,
+    NotColorized = 10,
   };
 
   bool IsSerumMode(Mode mode)

--- a/platforms/android/arm64-v8a/external.sh
+++ b/platforms/android/arm64-v8a/external.sh
@@ -40,6 +40,7 @@ cmake \
    -B build
 cmake --build build -- -j${NUM_PROCS}
 cp src/ZeDMD.h ../../third-party/include/
+cp -r third-party/include/komihash ../../third-party/include/
 cp -r third-party/include/sockpp ../../third-party/include/
 cp third-party/include/FrameUtil.h ../../third-party/include/
 cp third-party/runtime-libs/android/arm64-v8a/libsockpp.so ../../third-party/runtime-libs/android/arm64-v8a/

--- a/platforms/ios-simulator/arm64/external.sh
+++ b/platforms/ios-simulator/arm64/external.sh
@@ -34,6 +34,7 @@ cmake \
    -B build
 cmake --build build -- -j${NUM_PROCS}
 cp src/ZeDMD.h ../../third-party/include/
+cp -r third-party/include/komihash ../../third-party/include/
 cp -r third-party/include/sockpp ../../third-party/include/
 cp third-party/include/FrameUtil.h ../../third-party/include/
 cp -a third-party/build-libs/ios-simulator/arm64/libsockpp.a ../../third-party/build-libs/ios-simulator/arm64/

--- a/platforms/ios/arm64/external.sh
+++ b/platforms/ios/arm64/external.sh
@@ -34,6 +34,7 @@ cmake \
    -B build
 cmake --build build -- -j${NUM_PROCS}
 cp src/ZeDMD.h ../../third-party/include/
+cp -r third-party/include/komihash ../../third-party/include/
 cp -r third-party/include/sockpp ../../third-party/include/
 cp third-party/include/FrameUtil.h ../../third-party/include/
 cp -a third-party/build-libs/ios/arm64/libsockpp.a ../../third-party/build-libs/ios/arm64/

--- a/platforms/linux/aarch64/external.sh
+++ b/platforms/linux/aarch64/external.sh
@@ -36,6 +36,7 @@ cmake --build build -- -j${NUM_PROCS}
 cp src/ZeDMD.h ../../third-party/include/
 cp third-party/include/libserialport.h ../../third-party/include/
 cp third-party/include/cargs.h ../../third-party/include/
+cp -r third-party/include/komihash ../../third-party/include/
 cp -r third-party/include/sockpp ../../third-party/include/
 cp third-party/include/FrameUtil.h ../../third-party/include/
 cp third-party/runtime-libs/linux/aarch64/libcargs.so ../../third-party/runtime-libs/linux/aarch64/

--- a/platforms/linux/x64/external.sh
+++ b/platforms/linux/x64/external.sh
@@ -36,6 +36,7 @@ cmake --build build -- -j${NUM_PROCS}
 cp src/ZeDMD.h ../../third-party/include/
 cp third-party/include/libserialport.h ../../third-party/include/
 cp third-party/include/cargs.h ../../third-party/include/
+cp -r third-party/include/komihash ../../third-party/include/
 cp -r third-party/include/sockpp ../../third-party/include/
 cp third-party/include/FrameUtil.h ../../third-party/include/
 cp third-party/runtime-libs/linux/x64/libcargs.so ../../third-party/runtime-libs/linux/x64/

--- a/platforms/macos/arm64/external.sh
+++ b/platforms/macos/arm64/external.sh
@@ -36,6 +36,7 @@ cmake --build build -- -j${NUM_PROCS}
 cp src/ZeDMD.h ../../third-party/include/
 cp third-party/include/libserialport.h ../../third-party/include/
 cp third-party/include/cargs.h ../../third-party/include/
+cp -r third-party/include/komihash ../../third-party/include/
 cp -r third-party/include/sockpp ../../third-party/include/
 cp third-party/include/FrameUtil.h ../../third-party/include/
 cp third-party/runtime-libs/macos/arm64/libcargs.dylib ../../third-party/runtime-libs/macos/arm64/

--- a/platforms/macos/x64/external.sh
+++ b/platforms/macos/x64/external.sh
@@ -36,6 +36,7 @@ cmake --build build -- -j${NUM_PROCS}
 cp src/ZeDMD.h ../../third-party/include/
 cp third-party/include/libserialport.h ../../third-party/include/
 cp third-party/include/cargs.h ../../third-party/include/
+cp -r third-party/include/komihash ../../third-party/include/
 cp -r third-party/include/sockpp ../../third-party/include/
 cp third-party/include/FrameUtil.h ../../third-party/include/
 cp third-party/runtime-libs/macos/x64/libcargs.dylib ../../third-party/runtime-libs/macos/x64/

--- a/platforms/tvos/arm64/external.sh
+++ b/platforms/tvos/arm64/external.sh
@@ -34,6 +34,7 @@ cmake \
    -B build
 cmake --build build -- -j${NUM_PROCS}
 cp src/ZeDMD.h ../../third-party/include/
+cp -r third-party/include/komihash ../../third-party/include/
 cp -r third-party/include/sockpp ../../third-party/include/
 cp third-party/include/FrameUtil.h ../../third-party/include/
 cp -a third-party/build-libs/tvos/arm64/libsockpp.a ../../third-party/build-libs/tvos/arm64/

--- a/platforms/win/x64/external.sh
+++ b/platforms/win/x64/external.sh
@@ -33,6 +33,7 @@ cmake \
 cmake --build build --config ${BUILD_TYPE}
 cp src/ZeDMD.h ../../third-party/include/
 cp third-party/include/cargs.h ../../third-party/include/
+cp -r third-party/include/komihash ../../third-party/include/
 cp -r third-party/include/sockpp ../../third-party/include/
 cp third-party/include/FrameUtil.h ../../third-party/include/
 cp third-party/include/libserialport.h ../../third-party/include/

--- a/platforms/win/x86/external.sh
+++ b/platforms/win/x86/external.sh
@@ -35,6 +35,7 @@ cmake --build build --config ${BUILD_TYPE}
 cp src/ZeDMD.h ../../third-party/include/
 cp third-party/include/libserialport.h ../../third-party/include/
 cp third-party/include/cargs.h ../../third-party/include/
+cp -r third-party/include/komihash ../../third-party/include/
 cp -r third-party/include/sockpp ../../third-party/include/
 cp third-party/include/FrameUtil.h ../../third-party/include/
 cp third-party/build-libs/win/x86/cargs.lib ../../third-party/build-libs/win/x86/

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -23,6 +23,7 @@ Config::Config()
   m_pupExactColorMatch = true;
   m_framesTimeout = 0;
   m_framesToSkip = 0;
+  m_dumpNotColorizedFrames = false;
   m_zedmd = true;
   m_zedmdDevice.clear();
   m_zedmdDebug = false;

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -24,6 +24,7 @@ Config::Config()
   m_framesTimeout = 0;
   m_framesToSkip = 0;
   m_dumpNotColorizedFrames = false;
+  m_filterTransitionalFrames = false;
   m_zedmd = true;
   m_zedmdDevice.clear();
   m_zedmdDebug = false;

--- a/src/DMD.cpp
+++ b/src/DMD.cpp
@@ -1490,9 +1490,11 @@ void DMD::DumpDMDTxtThread()
       if (++bufferPosition >= DMDUTIL_FRAME_BUFFER_SIZE) bufferPosition = 0;
 
       if (m_pUpdateBufferQueue[bufferPosition]->depth <= 4 && m_pUpdateBufferQueue[bufferPosition]->hasData &&
-          (m_pUpdateBufferQueue[bufferPosition]->mode == Mode::Data ||
+          ((m_pUpdateBufferQueue[bufferPosition]->mode == Mode::Data && !dumpNotColorizedFrames) ||
            (m_pUpdateBufferQueue[bufferPosition]->mode == Mode::NotColorized && dumpNotColorizedFrames)))
       {
+        Log(DMDUtil_LogLevel_DEBUG, "DumpDMDTxt: hanlde frame, mode %d", m_pUpdateBufferQueue[bufferPosition]->mode);
+
         bool update = false;
         if (strcmp(m_romName, name) != 0)
         {
@@ -1547,8 +1549,7 @@ void DMD::DumpDMDTxtThread()
 
             if (f)
             {
-              if (passed[0] > 0 &&
-                  (!dumpNotColorizedFrames || m_pUpdateBufferQueue[bufferPosition]->mode == Mode::NotColorized))
+              if (passed[0] > 0)
               {
                 bool dump = true;
 

--- a/src/DMD.cpp
+++ b/src/DMD.cpp
@@ -1465,6 +1465,7 @@ void DMD::DumpDMDTxtThread()
 
   Config* const pConfig = Config::GetInstance();
   bool dumpNotColorizedFrames = pConfig->IsDumpNotColorizedFrames();
+  bool filterTransitionalFrames = pConfig->IsFilterTransitionalFrames();
 
   while (true)
   {
@@ -1493,8 +1494,6 @@ void DMD::DumpDMDTxtThread()
           ((m_pUpdateBufferQueue[bufferPosition]->mode == Mode::Data && !dumpNotColorizedFrames) ||
            (m_pUpdateBufferQueue[bufferPosition]->mode == Mode::NotColorized && dumpNotColorizedFrames)))
       {
-        Log(DMDUtil_LogLevel_DEBUG, "DumpDMDTxt: handle frame, mode %d", m_pUpdateBufferQueue[bufferPosition]->mode);
-
         bool update = false;
         if (strcmp(m_romName, name) != 0)
         {
@@ -1521,7 +1520,6 @@ void DMD::DumpDMDTxtThread()
         if (name[0] != '\0')
         {
           int length = (int)m_pUpdateBufferQueue[bufferPosition]->width * m_pUpdateBufferQueue[bufferPosition]->height;
-          Log(DMDUtil_LogLevel_DEBUG, "DumpDMDTxt: handle frame, length %d", length);
           if (update || (memcmp(renderBuffer[1], m_pUpdateBufferQueue[bufferPosition]->data, length) != 0))
           {
             passed[2] = (uint32_t)(std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -1529,7 +1527,7 @@ void DMD::DumpDMDTxtThread()
                                        .count());
             memcpy(renderBuffer[2], m_pUpdateBufferQueue[bufferPosition]->data, length);
 
-            if (m_pUpdateBufferQueue[bufferPosition]->depth == 2 &&
+            if (filterTransitionalFrames && m_pUpdateBufferQueue[bufferPosition]->depth == 2 &&
                 (passed[2] - passed[1]) < DMDUTIL_MAX_TRANSITIONAL_FRAME_DURATION)
             {
               int i = 0;

--- a/src/DMD.cpp
+++ b/src/DMD.cpp
@@ -874,6 +874,9 @@ void DMD::SerumThread()
               noSerumUpdate->depth = m_pUpdateBufferQueue[bufferPosition]->depth;
               noSerumUpdate->width = m_pUpdateBufferQueue[bufferPosition]->width;
               noSerumUpdate->height = m_pUpdateBufferQueue[bufferPosition]->height;
+              noSerumUpdate->hasData = true;
+              noSerumUpdate->hasSegData = false;
+              noSerumUpdate->hasSegData2 = false;
               memcpy(
                   noSerumUpdate->data, m_pUpdateBufferQueue[bufferPosition]->data,
                   (size_t)m_pUpdateBufferQueue[bufferPosition]->width * m_pUpdateBufferQueue[bufferPosition]->height);

--- a/src/DMD.cpp
+++ b/src/DMD.cpp
@@ -1493,7 +1493,7 @@ void DMD::DumpDMDTxtThread()
           ((m_pUpdateBufferQueue[bufferPosition]->mode == Mode::Data && !dumpNotColorizedFrames) ||
            (m_pUpdateBufferQueue[bufferPosition]->mode == Mode::NotColorized && dumpNotColorizedFrames)))
       {
-        Log(DMDUtil_LogLevel_DEBUG, "DumpDMDTxt: hanlde frame, mode %d", m_pUpdateBufferQueue[bufferPosition]->mode);
+        Log(DMDUtil_LogLevel_DEBUG, "DumpDMDTxt: handle frame, mode %d", m_pUpdateBufferQueue[bufferPosition]->mode);
 
         bool update = false;
         if (strcmp(m_romName, name) != 0)
@@ -1521,6 +1521,7 @@ void DMD::DumpDMDTxtThread()
         if (name[0] != '\0')
         {
           int length = (int)m_pUpdateBufferQueue[bufferPosition]->width * m_pUpdateBufferQueue[bufferPosition]->height;
+          Log(DMDUtil_LogLevel_DEBUG, "DumpDMDTxt: handle frame, length %d", length);
           if (update || (memcmp(renderBuffer[1], m_pUpdateBufferQueue[bufferPosition]->data, length) != 0))
           {
             passed[2] = (uint32_t)(std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -1540,6 +1541,8 @@ void DMD::DumpDMDTxtThread()
               }
               if (i == length)
               {
+                Log(DMDUtil_LogLevel_DEBUG, "DumpDMDTxt: skip transitional frame");
+
                 // renderBuffer[1] is a transitional frame, delete it.
                 memcpy(renderBuffer[1], renderBuffer[2], length);
                 passed[1] += passed[2];
@@ -1562,6 +1565,7 @@ void DMD::DumpDMDTxtThread()
                   }
                   else
                   {
+                    Log(DMDUtil_LogLevel_DEBUG, "DumpDMDTxt: skip duplicate frame");
                     dump = false;
                   }
                 }

--- a/src/DMD.cpp
+++ b/src/DMD.cpp
@@ -869,6 +869,8 @@ void DMD::SerumThread()
             }
             else if (dumpNotColorizedFrames)
             {
+              Log(DMDUtil_LogLevel_DEBUG, "Serum: unidentified frame detected");
+
               auto noSerumUpdate = std::make_shared<Update>();
               noSerumUpdate->mode = Mode::NotColorized;
               noSerumUpdate->depth = m_pUpdateBufferQueue[bufferPosition]->depth;

--- a/src/DMD.cpp
+++ b/src/DMD.cpp
@@ -20,7 +20,7 @@
 #include "FrameUtil.h"
 #include "Logger.h"
 #include "ZeDMD.h"
-#include "komihash.h"
+#include "komihash/komihash.h"
 #include "pupdmd.h"
 #include "serum-decode.h"
 #include "serum.h"


### PR DESCRIPTION
The filtering of WPC transitional frames is optional now.
Added a new mode to only dump frames that are not colorized.