### PR TITLE
Show not colorized frames

### DIFF
--- a/include/DMDUtil/Config.h
+++ b/include/DMDUtil/Config.h
@@ -51,6 +51,8 @@ class DMDUTILAPI Config
   void SetMaximumUnknownFramesToSkip(int framesToSkip) { m_framesToSkip = framesToSkip; }
   int GetIgnoreUnknownFramesTimeout() { return m_framesTimeout; }
   int GetMaximumUnknownFramesToSkip() { return m_framesToSkip; }
+  bool IsShowNotColorizedFrames() const { return m_showNotColorizedFrames; }
+  void SetShowNotColorizedFrames(bool showNotColorizedFrames) { m_showNotColorizedFrames = showNotColorizedFrames; }
   bool IsDumpNotColorizedFrames() const { return m_dumpNotColorizedFrames; }
   void SetDumpNotColorizedFrames(bool dumpNotColorizedFrames) { m_dumpNotColorizedFrames = dumpNotColorizedFrames; }
   bool IsFilterTransitionalFrames() const { return m_filterTransitionalFrames; }
@@ -103,6 +105,7 @@ class DMDUTILAPI Config
   bool m_pupExactColorMatch;
   int m_framesTimeout;
   int m_framesToSkip;
+  bool m_showNotColorizedFrames;
   bool m_dumpNotColorizedFrames;
   bool m_filterTransitionalFrames;
   bool m_zedmd;

--- a/include/DMDUtil/DMD.h
+++ b/include/DMDUtil/DMD.h
@@ -92,10 +92,11 @@ class DMDUTILAPI DMD
     NotColorized = 10,
   };
 
-  bool IsSerumMode(Mode mode)
+  bool IsSerumMode(Mode mode, bool showNotColorized = false)
   {
     return (mode == Mode::SerumV1 || mode == Mode::SerumV2_32 || mode == Mode::SerumV2_32_64 ||
-            mode == Mode::SerumV2_64 || mode == Mode::SerumV2_64_32);
+            mode == Mode::SerumV2_64 || mode == Mode::SerumV2_64_32 ||
+            (showNotColorized && mode == Mode::NotColorized));
   }
 
   bool IsSerumV2Mode(Mode mode)

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -23,6 +23,7 @@ Config::Config()
   m_pupExactColorMatch = true;
   m_framesTimeout = 0;
   m_framesToSkip = 0;
+  m_showNotColorizedFrames = false;
   m_dumpNotColorizedFrames = false;
   m_filterTransitionalFrames = false;
   m_zedmd = true;

--- a/src/DMD.cpp
+++ b/src/DMD.cpp
@@ -650,6 +650,9 @@ void DMD::ZeDMDThread()
   m_dmdFrameReady.load(std::memory_order_acquire);
   m_stopFlag.load(std::memory_order_acquire);
 
+  Config* const pConfig = Config::GetInstance();
+  bool showNotColorizedFrames = pConfig->IsShowNotColorizedFrames();
+
   while (true)
   {
     std::shared_lock<std::shared_mutex> sl(m_dmdSharedMutex);
@@ -669,7 +672,7 @@ void DMD::ZeDMDThread()
       bufferPosition = GetNextBufferQueuePosition(bufferPosition, updateBufferQueuePosition);
 
       if (m_pSerum &&
-          (!IsSerumMode(m_pUpdateBufferQueue[bufferPosition]->mode) ||
+          (!IsSerumMode(m_pUpdateBufferQueue[bufferPosition]->mode, showNotColorizedFrames) ||
            (m_pZeDMD->GetWidth() == 256 && m_pUpdateBufferQueue[bufferPosition]->mode == Mode::SerumV2_32_64) ||
            (m_pZeDMD->GetWidth() < 256 && m_pUpdateBufferQueue[bufferPosition]->mode == Mode::SerumV2_64_32)))
         continue;
@@ -782,6 +785,7 @@ void DMD::SerumThread()
     m_stopFlag.load(std::memory_order_acquire);
 
     Config* const pConfig = Config::GetInstance();
+    bool showNotColorizedFrames = pConfig->IsShowNotColorizedFrames();
     bool dumpNotColorizedFrames = pConfig->IsDumpNotColorizedFrames();
 
     while (true)
@@ -867,7 +871,7 @@ void DMD::SerumThread()
                 prevTriggerId = m_pSerum->triggerID;
               }
             }
-            else if (dumpNotColorizedFrames)
+            else if (showNotColorizedFrames || dumpNotColorizedFrames)
             {
               Log(DMDUtil_LogLevel_DEBUG, "Serum: unidentified frame detected");
 
@@ -1003,6 +1007,9 @@ void DMD::PixelcadeDMDThread()
   m_dmdFrameReady.load(std::memory_order_acquire);
   m_stopFlag.load(std::memory_order_acquire);
 
+  Config* const pConfig = Config::GetInstance();
+  bool showNotColorizedFrames = pConfig->IsShowNotColorizedFrames();
+
   while (true)
   {
     std::shared_lock<std::shared_mutex> sl(m_dmdSharedMutex);
@@ -1020,7 +1027,7 @@ void DMD::PixelcadeDMDThread()
     {
       bufferPosition = GetNextBufferQueuePosition(bufferPosition, updateBufferQueuePosition);
 
-      if (m_pSerum && !IsSerumMode(m_pUpdateBufferQueue[bufferPosition]->mode)) continue;
+      if (m_pSerum && !IsSerumMode(m_pUpdateBufferQueue[bufferPosition]->mode, showNotColorizedFrames)) continue;
 
       if (m_pUpdateBufferQueue[bufferPosition]->hasData || m_pUpdateBufferQueue[bufferPosition]->hasSegData)
       {
@@ -1218,6 +1225,9 @@ void DMD::RGB24DMDThread()
   m_dmdFrameReady.load(std::memory_order_acquire);
   m_stopFlag.load(std::memory_order_acquire);
 
+  Config* const pConfig = Config::GetInstance();
+  bool showNotColorizedFrames = pConfig->IsShowNotColorizedFrames();
+
   while (true)
   {
     std::shared_lock<std::shared_mutex> sl(m_dmdSharedMutex);
@@ -1235,7 +1245,7 @@ void DMD::RGB24DMDThread()
     {
       bufferPosition = GetNextBufferQueuePosition(bufferPosition, updateBufferQueuePosition);
 
-      if (m_pSerum && !IsSerumMode(m_pUpdateBufferQueue[bufferPosition]->mode)) continue;
+      if (m_pSerum && !IsSerumMode(m_pUpdateBufferQueue[bufferPosition]->mode, showNotColorizedFrames)) continue;
 
       if (!m_rgb24DMDs.empty() &&
           (m_pUpdateBufferQueue[bufferPosition]->hasData || m_pUpdateBufferQueue[bufferPosition]->hasSegData))

--- a/src/DMD.cpp
+++ b/src/DMD.cpp
@@ -723,7 +723,8 @@ void DMD::ZeDMDThread()
             memcpy(indexBuffer, m_pUpdateBufferQueue[bufferPosition]->data, frameSize);
             update = true;
           }
-          else if (!m_pSerum && m_pUpdateBufferQueue[bufferPosition]->mode == Mode::Data)
+          else if ((!m_pSerum && m_pUpdateBufferQueue[bufferPosition]->mode == Mode::Data) ||
+                   (showNotColorizedFrames && m_pUpdateBufferQueue[bufferPosition]->mode == Mode::NotColorized))
           {
             memcpy(indexBuffer, m_pUpdateBufferQueue[bufferPosition]->data, frameSize);
             update = true;
@@ -1108,7 +1109,8 @@ void DMD::PixelcadeDMDThread()
             memcpy(renderBuffer, m_pUpdateBufferQueue[bufferPosition]->data, length);
             update = true;
           }
-          else if (!m_pSerum && m_pUpdateBufferQueue[bufferPosition]->mode == Mode::Data)
+          else if ((!m_pSerum && m_pUpdateBufferQueue[bufferPosition]->mode == Mode::Data) ||
+                   (showNotColorizedFrames && m_pUpdateBufferQueue[bufferPosition]->mode == Mode::NotColorized))
           {
             memcpy(renderBuffer, m_pUpdateBufferQueue[bufferPosition]->data, length);
             update = true;
@@ -1290,7 +1292,8 @@ void DMD::RGB24DMDThread()
                                    m_pUpdateBufferQueue[bufferPosition]->r, m_pUpdateBufferQueue[bufferPosition]->g,
                                    m_pUpdateBufferQueue[bufferPosition]->b);
 
-            if (!m_pSerum && m_pUpdateBufferQueue[bufferPosition]->mode == Mode::Data)
+            if ((!m_pSerum && m_pUpdateBufferQueue[bufferPosition]->mode == Mode::Data) ||
+                (showNotColorizedFrames && m_pUpdateBufferQueue[bufferPosition]->mode == Mode::NotColorized))
             {
               if (memcmp(renderBuffer, m_pUpdateBufferQueue[bufferPosition]->data, length) != 0)
               {


### PR DESCRIPTION
For real pinballs it is helpful to see missing frames in the colorization, for example caused by different ROM versions.